### PR TITLE
Adds the "instruction" parameter to the Grouping parameters.

### DIFF
--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -124,7 +124,7 @@ module SEPA
 
     # Unique and consecutive identifier (used for the <PmntInf> blocks)
     def payment_information_identification(group)
-      "#{message_identification}/#{grouped_transactions.keys.index(group)+1}"
+      "#{group[:instruction]} SEPA #{message_identification}"
     end
 
     # Returns a key to determine the group to which the transaction belongs

--- a/lib/sepa_king/message/direct_debit.rb
+++ b/lib/sepa_king/message/direct_debit.rb
@@ -20,6 +20,7 @@ module SEPA
         local_instrument: transaction.local_instrument,
         sequence_type:    transaction.sequence_type,
         batch_booking:    transaction.batch_booking,
+        instruction:      transaction.instruction,
         account:          transaction.creditor_account || account
       }
     end


### PR DESCRIPTION
This will force one transaction per "group" (as long as you keep the instructions unique of course)

Some banks don't show the details for multiple transactions in one group, they only show the
payment_information_identification value...